### PR TITLE
Fix typo in table information comment

### DIFF
--- a/src/query_metadata.rs
+++ b/src/query_metadata.rs
@@ -45,7 +45,7 @@ impl QueryMetadata {
             from,
             selection,
         } = DestructuredQuery::destructure(statement)?;
-        //check and extract table informations from FROM clause
+        //check and extract table information from FROM clause
         let TableIdentWithAlias(table_name, table_alias) = TableIdentWithAlias::extract(from)?;
         //extract table name to be used in the SELECT clause
         let from_clause_identifier = table_alias.as_deref().map_or_else(


### PR DESCRIPTION
Changes "informations" to "information" in the comment to use correct singular form.
This is a minor documentation fix to improve code readability.